### PR TITLE
Added simple renameSessions PS-script

### DIFF
--- a/renameSessions.ps1
+++ b/renameSessions.ps1
@@ -1,0 +1,27 @@
+# Renames SID.mp4 to "SID - Title.mp4"
+param(
+	[Parameter(Mandatory=$false,HelpMessage="file of vmworld sessions to download",ValueFromPipeline=$true)][string]$sessionsToDownloadFile="us.txt"
+)
+
+$lines = Get-Content -Path $sessionsToDownloadFile | Where-Object { $_.Trim() -ne '' }
+
+foreach ($line in $lines) {
+	($title,$url) = $line -split "#"
+	$title = $title.replace("`:",'')
+	$title = $title.replace("`'",'')
+	$title = $title.replace("[",'')
+	$title = $title.replace("]",'')
+	$title = $title.replace("/",'_')
+	$title = $title.replace("\",'_')
+	$title = $title.replace("?",'')
+	$title = $title.trim()
+	$newName = $title + ".mp4"
+
+	($id,$name) = $title -split " - "
+	$oldName = $id + ".mp4"
+
+	if (Test-Path $oldName) {
+		Write-Host "Renaming $id..."
+		Rename-Item -Path $oldName $newName
+	}
+}


### PR DESCRIPTION
Simple PS script to rename files "SID.mp4" to "SID - Title.mp4"; e.g. useful when downloaded each session of the sessions list individually through the browser one by one ("Save link as").

When only having a folder full of MP4 files named after the session ID, it is quite hard to identify the topic about each file. So I've just written a script (with stolen parts from the downloadSessions.ps1 ;)) to rename them automatically based on the `us.txt` file.

```
PS C:\somepath\vmworld> wget https://raw.githubusercontent.com/lamw/vmworld2019-session-urls/master/us.txt -OutFile us.txt
PS C:\somepath\vmworld> .\renameSessions.ps1
Renaming ADV1337BU...
Renaming UEM1460BU...
Renaming HBI1729BU...
Renaming HBI1743BU...
[...]
```